### PR TITLE
Use a relative path for the data URL in MapViewer sample

### DIFF
--- a/MapViewerSample/etc/map.html
+++ b/MapViewerSample/etc/map.html
@@ -111,7 +111,7 @@ html,body,#map-canvas {
 		function loadData() {		
 			
 			// retreive data from input port of HTTPTupleView					
-			var url = window.location.protocol + "//" + window.location.host + "/map/data/ports/input/0/tuples";
+			var url = "data/ports/input/0/tuples";
 
 			// construct HTTP request and send 
 			var markerReq = new XMLHttpRequest();


### PR DESCRIPTION
The context provided by HTTPTupleView is intended to make URL paths easier to deal with (and fixed) by being relative to any files in the web-server.