### PR TITLE
Override default version of TLS when connecting to Twitter api, as Tw…

### DIFF
--- a/ReadAndStoreData/TwitterSmackdown/sample/TwitterStream.spl
+++ b/ReadAndStoreData/TwitterSmackdown/sample/TwitterStream.spl
@@ -32,6 +32,7 @@ composite TwitterStream
 				retryOnClose : true;
 				retryDelay : 60.0;
 				maxRetries : 3600;
+				vmArg: "-Dcom.ibm.jsse2.overrideDefaultTLS=true";
 		}
 		
 		// Filter to only include statuses (excluding for example, status deletes, etc.)


### PR DESCRIPTION
…itter API now requires TLS 1.2