### PR TITLE
Fix broken UDP and consistent region samples

### DIFF
--- a/Examples-for-beginners/079_user_defined_parallelism_06/com.acme.test/UDP6.spl
+++ b/Examples-for-beginners/079_user_defined_parallelism_06/com.acme.test/UDP6.spl
@@ -53,11 +53,14 @@ composite UDP6 {
 				file: "/tmp/079_udp_Test1.csv";
 				flush: 1u;
 		}
-		() as Printer = Custom(TransformedData1, TransformedData2) {
+		() as Printer = Custom(TransformedData1 as in0; TransformedData2 as in1) {
 			logic
-			onTuple in0: {
-				println(in0);
-			}
+				onTuple in0: {
+					println(in0);
+				}
+				onTuple in1: {
+					println(in1);
+				}
 		}  	
 
 }

--- a/Examples-for-beginners/080_user_defined_parallelism_07/com.acme.test/UDP7.spl
+++ b/Examples-for-beginners/080_user_defined_parallelism_07/com.acme.test/UDP7.spl
@@ -60,11 +60,14 @@ composite UDP7 {
 				file: "/tmp/080_udp_Test1.csv";
 				flush: 1u;
 		}
-		() as Printer = Custom(TransformedData , TransformedData2 as in0){
+		() as Printer = Custom(TransformedData1 as in0; TransformedData2 as in1){
 			logic
-			onTuple in0: {
-				println(in0);
-			}
+				onTuple in0: {
+					println(in0);
+				}
+				onTuple in1: {
+					println(in1);
+				}
 		}  	
 
 }

--- a/Examples-for-beginners/094_consistent_region_spl_05/com.acme.test/ConsistentRegion5.spl
+++ b/Examples-for-beginners/094_consistent_region_spl_05/com.acme.test/ConsistentRegion5.spl
@@ -100,7 +100,7 @@ composite ConsistentRegion5 {
 				file: "/tmp/094_consistent_region_result1.txt";
 				flush: 1u;
 		}
-		() as Printer = Custom(FinalData as in0){
+		() as Printer1 = Custom(FinalData as in0){
 			logic
 			onTuple in0: {
 				println(in0);
@@ -131,7 +131,7 @@ composite ConsistentRegion5 {
 				file: "/tmp/094_consistent_region_autonomous_results.txt";
 				flush: 1u;
 		}
-		() as Printer = Custom(TransformedData2 as in0){
+		() as Printer2 = Custom(TransformedData2 as in0){
 			logic
 			onTuple in0: {
 				println(in0);


### PR DESCRIPTION
## 079_user_defined_parallelism_06

Before:
```
$ sc -a -M com.acme.test::UDP6
com.acme.test/UDP6.spl:58:4: CDISP0021E ERROR: A port that corresponds to the in0 identifier was not found.
com.acme.test/UDP6.spl:58:12: CDISP0053E ERROR: An unknown identifier was referenced in the SPL program: in0.
com.acme.test/UDP6.spl:59:13: CDISP0053E ERROR: An unknown identifier was referenced in the SPL program: in0.

CDISP0092E ERROR: Because of previous compilation errors, the compile process cannot continue.
```

After:
```
$ sc -a -M com.acme.test::UDP6
Checking the constraints.
Creating the types.
Creating the functions.
Creating the operators.
Creating the standalone application.
Creating the application model.
Building the binaries.
 [CXX-type] tuple<int32 i>
 [CXX-operator] MyData
 [CXX-operator] EnrichedData
 [CXX-operator] MySink
 [CXX-operator] Printer
 [CXX-operator] TransformedData1.A
 [CXX-operator] TransformedData1.B
 [CXX-standalone] standalone
 [LD-standalone] standalone
 [LN-standalone] standalone 
 [LD-so] so TransformedData1.A
 [LD-so] so TransformedData1.B
 [LD-so] so EnrichedData
 [LD-so] so MyData
 [LD-so] so Printer
 [LD-so] so MySink
 [Bundle] com.acme.test.UDP6.sab
```

## 080_user_defined_parallelism_07

Before:
```
$ sc -a -M com.acme.test::UDP7
com.acme.test/UDP7.spl:63:26: CDISP0053E ERROR: An unknown identifier was referenced in the SPL program: TransformedData.

CDISP0092E ERROR: Because of previous compilation errors, the compile process cannot continue.
```

After:
```
$ sc -a -M com.acme.test::UDP7
Checking the constraints.
Creating the types.
Creating the functions.
Creating the operators.
Creating the standalone application.
Creating the application model.
Building the binaries.
 [CXX-type] tuple<int32 i>
 [CXX-operator] MyData
 [CXX-operator] EnrichedData
 [CXX-operator] MySink
 [CXX-operator] Printer
 [CXX-operator] TransformedData1.A
 [CXX-operator] TransformedData1.B
 [CXX-standalone] standalone
 [LD-standalone] standalone
 [LN-standalone] standalone 
 [LD-so] so TransformedData1.A
 [LD-so] so Printer
 [LD-so] so EnrichedData
 [LD-so] so TransformedData1.B
 [LD-so] so MyData
 [LD-so] so MySink
 [Bundle] com.acme.test.UDP7.sab
```

## 094_consistent_region_spl_05

Before:
```
$ sc -a -M com.acme.test::ConsistentRegion5
com.acme.test/ConsistentRegion5.spl:134:3: CDISP0025E ERROR: The following identifier is a duplicate: Printer.
com.acme.test/ConsistentRegion5.spl:103:3: CDISP0032D DETAILS: The Printer identifier was previously defined at this location.

CDISP0092E ERROR: Because of previous compilation errors, the compile process cannot continue.
```

After:
```
$ sc -a -M com.acme.test::ConsistentRegion5
Checking the constraints.
Creating the types.
Creating the functions.
Creating the operators.
Creating the standalone application.
Creating the application model.
Building the binaries.
 [CXX-type] tuple<int32 i,rstring str>
 [CXX-type] tuple<int32 i>
 [CXX-operator] TestData
 [CXX-operator] TransformedData1
 [CXX-operator] FinalData
 [CXX-operator] MySink1
 [CXX-operator] Printer1
 [CXX-operator] TransformedData2
 [CXX-operator] MySink2
 [CXX-operator] Printer2
 [CXX-operator] JCP.JCP
 [LD-so] so TransformedData2
 [CXX-standalone] standalone
 [LD-so] so FinalData
 [LD-so] so Printer1
 [LD-standalone] standalone
 [LD-so] so TestData
 [LN-standalone] standalone 
 [LD-so] so TransformedData1
 [LD-so] so Printer2
 [LD-so] so MySink1
 [LD-so] so JCP.JCP
 [LD-so] so MySink2
 [Bundle] com.acme.test.ConsistentRegion5.sab
```